### PR TITLE
chore: fix travis build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 
 before_script:
-  cp .env.testing.example .env.testing
+  cp .env.test.example .env.test
 


### PR DESCRIPTION
ERROR:
cp: cannot stat ‘.env.testing.example’: No such file or directory

RESOLUTION:
update travis.yml to use .env.test.example instead of
.env.testing.example.

Closes #18